### PR TITLE
Introduce the ability of run only Sophos XG ban

### DIFF
--- a/playbook.yml
+++ b/playbook.yml
@@ -138,4 +138,6 @@
         # Change to Closed
         - include: tasks/jira.yml jira_task=transition transition_id="41" transition_type="Closed" # 11 In Progress, 21 Under Rewiew, 31 Approved, 41 Closed
         when: sophos_ban_status[0] == 'Configuration applied successfully'
+        tags:
+          - manual_ban
       when: ipdb_score is version('50', '>=')


### PR DESCRIPTION
Introduce the ability to run only BAN on Sophos XG task/block by using tag `manual_ban`. This is useful for such situation where an IP have a low AbuseIPDB reputation but it could be an actual threat.